### PR TITLE
Customize permissions so that cobol resources are read and writable

### DIFF
--- a/src/main/groovy/de/sebastianruziczka/buildcycle/CobolRunExecutable.groovy
+++ b/src/main/groovy/de/sebastianruziczka/buildcycle/CobolRunExecutable.groovy
@@ -55,6 +55,8 @@ class CobolRunExecutable {
 			onlyIf {!project.fileTree(conf.srcMainPath).getFiles().isEmpty()}
 			from conf.projectFileResolver(conf.resMainPath).absolutePath
 			into conf.projectFileResolver(conf.binMainPath).absolutePath
+			//Customize permissions so that resources are read and writable
+			fileMode = 0666
 		}
 	}
 }


### PR DESCRIPTION
Copying files from the resources folder does not ensure that they have read and write permissions. Very annoying if then the compiled Cobol program does not work as expected. Fixed attached.